### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ contextlog
 ==========
 [![Build Status](https://travis-ci.org/mdevaev/contextlog.svg?branch=master)](https://travis-ci.org/mdevaev/contextlog)
 [![Coverage Status](https://coveralls.io/repos/mdevaev/contextlog/badge.png?branch=master)](https://coveralls.io/r/mdevaev/contextlog?branch=master)
-[![Latest Version](https://pypip.in/v/contextlog/badge.png)](https://pypi.python.org/pypi/contextlog/)
+[![Latest Version](https://img.shields.io/pypi/v/contextlog.svg)](https://pypi.python.org/pypi/contextlog/)
 
 
 ##Context-based logger and formatters collection##


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20contextlog))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `contextlog`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.